### PR TITLE
fix: default project name option

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ const TASKS_FOLDER = 'tasks';
 const config = require('./config.json');
 const commandLineOptions = {
   string: ['project', 'zip'],
-  default: {project: 'hello_world', 'zip': uuid() + '.zip'},
+  default: {project: 'hello-world', 'zip': uuid() + '.zip'},
   alias: {'project': 'p', 'zip': 'z'}
 };
 var providedArguments = minimist(process.argv.slice(2), commandLineOptions);


### PR DESCRIPTION
Running cli without a project flag will fallback to `hello_world` project which does not exist. 
