### PR TITLE
Upgrade open to secure package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,18 +10,18 @@
   "license": "Platform License",
   "private": true,
   "dependencies": {
-    "gulp": "^4.0.0",
+    "gulp": "4.0.2",
     "gulp-html-replace": "^1.6.2",
     "gulp-rename": "^1.2.2",
     "gulp-rimraf": "^0.2.2",
-    "gulp-webserver": "^0.9.1",
+    "gulp-webserver": ">=0.9.1",
     "gulp-zip": "^4.1.0",
     "npm": "^6.9.0",
-    "open": "^0.0.5",
+    "open": "6.3.0",
     "request": "^2.83.0"
   },
   "devDependencies": {
-    "gulp-cli": "^2.0.1",
+    "gulp-cli": "^2.2.0",
     "semistandard": "^12.0.1"
   },
   "scripts": {

--- a/tasks/upload.js
+++ b/tasks/upload.js
@@ -29,10 +29,11 @@ module.exports = function(gulp, config, commandLineArguments) {
       'make',
       'replace-sdk',
       'archive',
-      function() {
+      function(done) {
         upload(config.archivesFolder, commandLineArguments.zip)
           .then(function() {
             console.log('Success');
+            done();
             return Promise.resolve("Success");
           })
           .catch(function(error) {
@@ -81,8 +82,7 @@ module.exports = function(gulp, config, commandLineArguments) {
               console.log('Bundle uploaded via the graph API');
               console.log("Don't forget you need to publish the build");
               console.log('Opening developer dashboard...');
-              open(openUrl);
-              resolve();
+              return open(openUrl).then(resolve);
             } else {
               reject(new Error('Unexpected API response: ' + response.body));
             }


### PR DESCRIPTION
The old 'open' version is not maintained and insecure. This updates to a version that uses the newer official 'open' package. While I was at it, I upgraded a couple of the other dependencies that threw warnings on the yarn install.

Tested that upload flow still succeeds after the upgrade.
![Screen Shot 2019-06-21 at 2 33 48 PM](https://user-images.githubusercontent.com/2685006/59952580-9d9aff80-9431-11e9-8c39-0b22e78c9934.png)